### PR TITLE
Use `debian:bookworm` for prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mv "./$CONFIG" /config
 RUN cargo build --release
 RUN mv ./target/release/pandoras_pot /pandoras_pot
 
-FROM rust:1.75
+FROM debian:bookworm
 
 COPY --from=build /pandoras_pot /pandoras_pot
 COPY --from=build /config /config


### PR DESCRIPTION
Reduces image size drastically, no need for full toolchain.

I have experimented with using a musl version to use `scratch`, but I'm not convinced. Same for alpine.