### PR TITLE
FEAT: Use bytes, remove axum_streams as dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +109,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "prost",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -463,6 +470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,7 +524,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6ad68e26d51a9558f65e93b9795c9422630d0932717a3235668bb9ab71e3fd"
 dependencies = [
- "itertools",
+ "itertools 0.9.0",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -599,6 +615,7 @@ version = "0.4.9"
 dependencies = [
  "axum",
  "axum-streams",
+ "bytes",
  "futures",
  "home",
  "markov",
@@ -688,6 +705,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "anyhow"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,9 +57,6 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -93,26 +84,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-streams"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f2b249e5711a934fce7b81a04a44033ecda0d74d2632cafaea2d8c3cc260f"
-dependencies = [
- "axum",
- "bytes",
- "cargo-husky",
- "futures",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "prost",
- "tokio",
- "tokio-stream",
- "tokio-util",
 ]
 
 [[package]]
@@ -147,12 +118,6 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cargo-husky"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
@@ -202,15 +167,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -470,15 +426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,7 +471,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6ad68e26d51a9558f65e93b9795c9422630d0932717a3235668bb9ab71e3fd"
 dependencies = [
- "itertools 0.9.0",
+ "itertools",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -614,10 +561,10 @@ name = "pandoras_pot"
 version = "0.4.9"
 dependencies = [
  "axum",
- "axum-streams",
  "bytes",
  "futures",
  "home",
+ "http-body",
  "markov",
  "rand 0.8.5",
  "serde",
@@ -705,29 +652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -888,33 +812,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ tokio-stream = { version = "0.1" }
 tower = { version = "0.4", default-features = false, features = ["limit", "buffer"] }
 tower-http = { version = "0.5", default-features = false, features = ["trace"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "http2", "matched-path", "original-uri", "tokio", "tower-log", "tracing"]}
-axum-streams = { version = "0.12", features=["protobuf"] }
 futures = "0.3.30"
 serde = { version = "1.0", features = [ "derive" ]}
 toml = "0.8.8"
@@ -37,6 +36,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"]}
 markov = { version = "1.1.0", default-features = false, features = ["itertools"]}
 bytes = "1.5.0"
+http-body = "1.0.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio-stream = { version = "0.1" }
 tower = { version = "0.4", default-features = false, features = ["limit", "buffer"] }
 tower-http = { version = "0.5", default-features = false, features = ["trace"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "http2", "matched-path", "original-uri", "tokio", "tower-log", "tracing"]}
-axum-streams = { version = "0.12", features=["text"] }
+axum-streams = { version = "0.12", features=["protobuf"] }
 futures = "0.3.30"
 serde = { version = "1.0", features = [ "derive" ]}
 toml = "0.8.8"
@@ -36,6 +36,7 @@ home = "0.5.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"]}
 markov = { version = "1.1.0", default-features = false, features = ["itertools"]}
+bytes = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -5,11 +5,13 @@ pub(crate) mod random_generator;
 pub(crate) mod static_generator;
 
 use std::{
+    fmt::Debug,
     sync::Arc,
     time::{self, Duration},
 };
 
 use crate::config::GeneratorConfig;
+use bytes::Bytes;
 use futures::Stream;
 use tokio::sync::{mpsc::Receiver, Semaphore};
 
@@ -33,7 +35,7 @@ pub(crate) enum GeneratorContainer {
 /// outputting infinite amounts of very useful strings.
 pub trait Generator
 where
-    Self: Sync + Iterator<Item = String> + Clone + Send + 'static,
+    Self: Sync + Iterator<Item = Bytes> + Clone + Send + 'static + Debug,
 {
     /// Creates the generator from a config.
     fn from_config(config: GeneratorConfig) -> Self;
@@ -46,7 +48,7 @@ where
 
     /// Returns an infinite stream using this generator, prepending `<html><body>\n` to the
     /// first chunk.
-    fn into_receiver(mut self) -> Receiver<String> {
+    fn into_receiver(mut self) -> Receiver<Bytes> {
         // To provide accurate stats, the buffer must be 1
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 
@@ -64,16 +66,17 @@ where
             // For the first value we want to prepend something to make it look like HTML.
             // We don't want to just chain it, because then the first chunk of the body always
             // looks the same.
-            let first_msg = format!("<html><body>{}", self.next().expect("next returned None"));
-            let first_msg_size = first_msg.as_bytes().len();
+            // let head = Bytes::from("<html><body>");
+            // let first_msg = head.chain(self.next().expect("next returned None"));
+            // // let first_msg_size = first_msg.len();
             let start_time = time::SystemTime::now();
-            match tx.send(first_msg).await {
-                Ok(_) => bytes_written += first_msg_size,
-                Err(_) => {
-                    tracing::info!("Stream broken before first message could be sent");
-                    return;
-                }
-            }
+            // match tx.send(first_msg).await {
+            //     Ok(_) => bytes_written += 0, //first_msg_size,
+            //     Err(_) => {
+            //         tracing::info!("Stream broken before first message could be sent");
+            //         return;
+            //     }
+            // }
 
             // Don't want to call `self.config()` over and over
             let time_limit = self.config().time_limit;
@@ -105,7 +108,7 @@ where
 
                 // The size may be dynamic if the generator does not have a strict
                 // chunk size
-                let s_size = s.as_bytes().len();
+                let s_size = s.len();
                 match tx.send(s).await {
                     Ok(_) => bytes_written += s_size,
                     Err(_) => {
@@ -124,7 +127,7 @@ where
         rx
     }
 
-    fn into_stream(self) -> impl Stream<Item = String> {
+    fn into_stream(self) -> impl Stream<Item = Bytes> {
         tokio_stream::wrappers::ReceiverStream::new(self.into_receiver())
     }
 }

--- a/src/generator/markov_generator.rs
+++ b/src/generator/markov_generator.rs
@@ -1,5 +1,6 @@
 use std::{fs, process::exit, sync::Arc};
 
+use bytes::Bytes;
 use markov::Chain;
 use tokio::sync::Semaphore;
 
@@ -69,7 +70,7 @@ impl Generator for MarkovChainGenerator {
 }
 
 impl Iterator for MarkovChainGenerator {
-    type Item = String;
+    type Item = Bytes;
 
     fn next(&mut self) -> Option<Self::Item> {
         let desired_size = self.config().chunk_size - P_TAG_SIZE;
@@ -81,7 +82,7 @@ impl Iterator for MarkovChainGenerator {
             // each time
             result.push_str(&self.chain.generate_str());
         }
-        Some(format!("<p>\n{}\n</p>\n", result))
+        Some(Bytes::from(format!("<p>\n{}\n</p>\n", result)))
     }
 }
 

--- a/src/generator/random_generator.rs
+++ b/src/generator/random_generator.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::config::GeneratorConfig;
+use bytes::Bytes;
 use rand::{
     distributions::{Alphanumeric, DistString},
     rngs::SmallRng,
@@ -38,13 +39,13 @@ impl Default for RandomGenerator {
 }
 
 impl Iterator for RandomGenerator {
-    type Item = String;
+    type Item = Bytes;
 
     fn next(&mut self) -> Option<Self::Item> {
         // No need to be secure, we are smacking bots
         let mut smol_rng = SmallRng::from_entropy();
         let s = Alphanumeric.sample_string(&mut smol_rng, self.config().chunk_size - P_TAG_SIZE);
-        Some(format!("<p>\n{}\n</p>\n", s))
+        Some(Bytes::from(format!("<p>\n{}\n</p>\n", s)))
     }
 }
 

--- a/src/generator/static_generator.rs
+++ b/src/generator/static_generator.rs
@@ -2,6 +2,8 @@ use std::{fs, process::exit, sync::Arc};
 
 use tokio::sync::Semaphore;
 
+use bytes::Bytes;
+
 use crate::{
     config::{GeneratorConfig, GeneratorType},
     error_code,
@@ -13,7 +15,7 @@ use super::Generator;
 #[derive(Clone, Debug)]
 pub(crate) struct StaticGenerator {
     config: GeneratorConfig,
-    data: String,
+    data: Bytes,
     semaphore: Arc<Semaphore>,
 }
 
@@ -28,7 +30,7 @@ impl Generator for StaticGenerator {
                 let semaphore = Arc::new(Semaphore::new(config.max_concurrent()));
                 Self {
                     config,
-                    data,
+                    data: Bytes::from(data),
                     semaphore,
                 }
             }
@@ -52,7 +54,7 @@ impl Default for StaticGenerator {
 }
 
 impl Iterator for StaticGenerator {
-    type Item = String;
+    type Item = Bytes;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.data.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,11 @@ async fn text_stream(gen: GeneratorContainer) -> impl IntoResponse {
     headers.insert(CONTENT_TYPE, "text/html; charset=utf-8".parse().unwrap());
 
     match gen {
-        GeneratorContainer::Random(g) => StreamBodyAs::text(g.into_stream()).headers(headers),
-        GeneratorContainer::MarkovChain(g) => StreamBodyAs::text(g.into_stream()).headers(headers),
-        GeneratorContainer::Static(g) => StreamBodyAs::text(g.into_stream()).headers(headers),
+        GeneratorContainer::Random(g) => StreamBodyAs::protobuf(g.into_stream()).headers(headers),
+        GeneratorContainer::MarkovChain(g) => {
+            StreamBodyAs::protobuf(g.into_stream()).headers(headers)
+        }
+        GeneratorContainer::Static(g) => StreamBodyAs::protobuf(g.into_stream()).headers(headers),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod error_code;
 mod generator;
 mod handler;
+mod stream_body;
 
 use axum::{
     error_handling::HandleErrorLayer,
@@ -11,10 +12,10 @@ use axum::{
     routing::*,
     BoxError, Router,
 };
-use axum_streams::StreamBodyAs;
 use config::Config;
 use generator::{random_generator::RandomGenerator, Generator, GeneratorContainer};
 use std::{fs, path::PathBuf, process::exit, time::Duration};
+use stream_body::StreamBody;
 use tokio::net::TcpListener;
 use tower::{buffer::BufferLayer, limit::RateLimitLayer, ServiceBuilder};
 use tracing_subscriber::prelude::*;
@@ -31,11 +32,11 @@ async fn text_stream(gen: GeneratorContainer) -> impl IntoResponse {
     headers.insert(CONTENT_TYPE, "text/html; charset=utf-8".parse().unwrap());
 
     match gen {
-        GeneratorContainer::Random(g) => StreamBodyAs::protobuf(g.into_stream()).headers(headers),
+        GeneratorContainer::Random(g) => StreamBody::from_stream(g.into_stream()).headers(headers),
         GeneratorContainer::MarkovChain(g) => {
-            StreamBodyAs::protobuf(g.into_stream()).headers(headers)
+            StreamBody::from_stream(g.into_stream()).headers(headers)
         }
-        GeneratorContainer::Static(g) => StreamBodyAs::protobuf(g.into_stream()).headers(headers),
+        GeneratorContainer::Static(g) => StreamBody::from_stream(g.into_stream()).headers(headers),
     }
 }
 

--- a/src/stream_body.rs
+++ b/src/stream_body.rs
@@ -1,0 +1,68 @@
+//! This is basically a bastardisation of `<https://github.com/abdolence/axum-streams-rs>`, but
+//! with less finesse.
+//!
+//! The whole purpose of all this is to be able to stream raw (UTF-8) bytes as an HTTP body.
+//! We can rely on UTF-8 since the bytes have once been a string in Rust. I think. Who cares,
+//! I think the bot reading the thing won't have time to care...
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::{
+    body::Body,
+    http::{HeaderMap, Response},
+    response::IntoResponse,
+};
+use bytes::Bytes;
+use futures::{stream::BoxStream, Stream, StreamExt};
+use http_body::Frame;
+
+pub struct StreamBody<'a> {
+    stream: BoxStream<'a, Result<Frame<axum::body::Bytes>, axum::Error>>,
+    trailers: Option<HeaderMap>,
+}
+
+impl<'a> StreamBody<'a> {
+    pub fn from_stream(stream: impl Stream<Item = Bytes> + Send + 'a) -> Self {
+        Self {
+            stream: Box::pin(stream.map(axum::body::Bytes::from).map(Frame::data).map(Ok)),
+            trailers: None,
+        }
+    }
+}
+
+impl<'a> StreamBody<'a> {
+    /// Set headers for the body.
+    pub fn headers(mut self, headers: HeaderMap) -> Self {
+        self.trailers = Some(headers);
+        self
+    }
+}
+
+impl<'a> http_body::Body for StreamBody<'a> {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.stream).poll_next_unpin(cx)
+    }
+}
+
+impl IntoResponse for StreamBody<'static> {
+    fn into_response(mut self) -> Response<Body> {
+        let headers = if let Some(trailers) = self.trailers.take() {
+            trailers
+        } else {
+            HeaderMap::new()
+        };
+
+        let mut response: Response<Body> = Response::new(Body::new(self));
+        *response.headers_mut() = headers;
+        response
+    }
+}


### PR DESCRIPTION
I need to do some more benchmarking, but basically this removes cloning from `StaticGenerator` if I understand things correctly (it's a cheap Arc being passed around). I need to check the others, but the thing is crazy fast.