### PR TITLE
Allow prefix for first message to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ health_port = "8081"
 
 [generator]
 # The size of each generated chunk in bytes. Has a big impact on performance, so
-# play around a bit! Note that if this is set too low (like 10 bytes), `pandoras_pot`
-# will refuse to run.
+# play around a bit! Note that if this is set too low (smaller than prefix size),
+# `pandoras_pot` will refuse to run.
 chunk_size = 16384 # 1024 * 16
 # The type of generator to be used
 type = { name = "random" }
@@ -303,6 +303,13 @@ size_limit = 0
 # How many chunks should be buffered for each connection. Higher values mean
 # more memory usage, but may lead to increased performance. Must be >= 1.
 chunk_buffer = 20
+
+# Prefix that will be used for the first message to an incoming connection.
+# Usually used to set an HTML prefix. Can be set to "" to disable.
+#
+# Example usage: Set to "{" for a static generator using a JSON file to make
+# output look like a valid stream of JSON that will eventually end (it won't).
+prefix = "<!DOCTYPE html><html><body>"
 
 [logging]
 # Output file for logs.

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,14 @@ pub(crate) struct GeneratorConfig {
     /// usage, but may lead to increased performance. Must be >= 1.
     #[serde(default = "default_generator_chunk_buffer")]
     pub chunk_buffer: usize,
+
+    /// Prefix that will be used for the first message to an incoming connection.
+    /// Usually used to set an HTML prefix. Can be set to "" to disable.
+    ///
+    /// Example usage: Set to "{" for a static generator using a JSON file to make
+    /// output look like a valid stream of JSON that will eventually end (it won't).
+    #[serde(default = "default_generator_prefix")]
+    pub prefix: String,
 }
 
 // While one could argue being able to pass strings in data as well is nicer, we quickly run into the
@@ -193,6 +201,7 @@ impl Default for GeneratorConfig {
             default_generator_time_limit(),
             default_generator_size_limit(),
             default_generator_chunk_buffer(),
+            default_generator_prefix(),
         )
     }
 }
@@ -205,6 +214,7 @@ impl GeneratorConfig {
         time_limit: u64,
         size_limit: usize,
         chunk_buffer: usize,
+        prefix: String,
     ) -> Self {
         Self {
             chunk_size,
@@ -213,6 +223,7 @@ impl GeneratorConfig {
             time_limit,
             size_limit,
             chunk_buffer,
+            prefix,
         }
     }
 
@@ -251,6 +262,10 @@ const fn default_generator_size_limit() -> usize {
 
 const fn default_generator_chunk_buffer() -> usize {
     20
+}
+
+fn default_generator_prefix() -> String {
+    "<!DOCTYPE html><html><body>".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -19,14 +19,6 @@ use tracing::Instrument;
 
 use self::{markov_strategy::MarkovChain, random_strategy::Random, static_strategy::Static};
 
-/// Size of wrapping a string in a "<p>\n{yourstring}\n</p>\n".
-/// `generator.chunk_size` must be larger than this.
-pub(crate) const P_TAG_SIZE: usize = 10;
-
-/// Prefix to be added to the first sent generated message to make it look like
-/// a very real and legit HTML page.
-pub const HTML_PREFIX: &str = "<!DOCTYPE html><html><body>";
-
 /// Container for generators
 #[derive(Clone, Debug)]
 pub(crate) enum GeneratorStrategyContainer {
@@ -99,7 +91,7 @@ impl Generator {
                 // For the first value we want to prepend something to make it look like HTML.
                 // We don't want to just chain it, because then the first chunk of the body always
                 // looks the same.
-                let mut first_msg = BytesMut::from(HTML_PREFIX);
+                let mut first_msg = BytesMut::from(self.config.prefix.as_str());
                 if let Some(first_gen) = gen.recv().await {
                     first_msg.extend(first_gen);
                 } else {
@@ -209,6 +201,7 @@ mod tests {
                 0, // No limit
                 0, // No limit
                 1,
+                "<DOCTYPE html>".to_string(),
             ));
 
             let g = Generator::from_config(config);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -42,7 +42,7 @@ pub trait GeneratorStrategy {
     /// dropped to avoid leaking resources.
     ///
     /// Implementors can, but do not have to, think about HTML. Note that the first message will be
-    /// prefixed with [`HTML_PREFIX`].
+    /// prefixed with config.generator.prefix.
     fn start(self, tx: mpsc::Sender<Bytes>);
 }
 
@@ -66,8 +66,8 @@ impl Generator {
         self.permits.clone()
     }
 
-    /// Returns an infinite stream using this generator strategy, prepending [`HTML_PREFIX`] to the
-    /// first chunk.
+    /// Returns an infinite stream using this generator strategy, prepending generator.prefix to
+    /// the first chunk.
     fn into_receiver<T>(self, strategy: T) -> mpsc::Receiver<Bytes>
     where
         T: GeneratorStrategy + Send + 'static,

--- a/src/generator/random_strategy.rs
+++ b/src/generator/random_strategy.rs
@@ -8,7 +8,7 @@ use rand::{
 use tokio::sync::mpsc;
 use tracing::instrument;
 
-use super::{GeneratorStrategy, P_TAG_SIZE};
+use super::GeneratorStrategy;
 
 /// Generates `chunk_size` of completely random text.
 #[derive(Clone, Debug)]
@@ -31,7 +31,7 @@ impl GeneratorStrategy for Random {
             // No need to be secure, we are smacking bots
             let mut smol_rng = SmallRng::from_entropy();
             loop {
-                let s = Alphanumeric.sample_string(&mut smol_rng, self.chunk_size - P_TAG_SIZE);
+                let s = Alphanumeric.sample_string(&mut smol_rng, self.chunk_size);
                 let res = Bytes::from(format!("<p>\n{s}\n</p>\n"));
 
                 if tx.blocking_send(res).is_err() {


### PR DESCRIPTION
Also removes some calculations trying to make the first message match the chunk size, because honestly it's just complicating something that doesn't matter at all.