### PR TITLE
Add deploy to releases on version tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,12 @@
 name: Deploy
 
-on: push
-#   push:
-#     branches:
-#       - "main"
-#     tags:
-#       - "[0-9]+.[0-9]+.[0-9]+"
-#
-# permissions:
-#   contents: write
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
 
 jobs:
   build-and-upload:
@@ -51,11 +49,11 @@ jobs:
           tar -czf "$result" "$dirname"
           shasum -a 256 "$result" > "$result.sha256"
           echo "RESULT=$result" >> $GITHUB_ENV
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   with:
-      #     generate_release_notes: true
-      #     files: |
-      #       ${{ env.RESULT }}
-      #       ${{ env.RESULT }}.sha256
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            ${{ env.RESULT }}
+            ${{ env.RESULT }}.sha256

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get the release version from the tag
         shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" | tee --append $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -49,7 +49,7 @@ jobs:
           result="$dirname.tar.gz"
           tar -czf "$result" "$dirname"
           sha256sum "$result" > "$result.sha256"
-          echo "RESULT=$result" >> $GITHUB_ENV
+          echo "RESULT=$result" | tee --append $GITHUB_ENV
       # - name: Release
       #   uses: softprops/action-gh-release@v1
       #   with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy
+
+on:
+  push
+  # push:
+  #   branches:
+  #     - "main"
+  #   tags:
+  #     - "[0-9]+.[0-9]+.[0-9]+"
+
+# permissions:
+#   contents: write
+
+jobs:
+  build-and-upload:
+    name: Build and upload
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get the release version from the tag
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Create archive
+        shell: bash
+        run: |
+          binary_name="pandoras_pot"
+          dirname="$binary_name-${{ env.VERSION }}-${{ matrix.target }}"
+          mkdir "$dirname"
+          mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
+          result="$dirname.tar.gz"
+          tar -czf "$result" "$dirname"
+          sha256sum "$result" > "$result.sha256"
+          echo "RESULT=$result" >> $GITHUB_ENV
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: |
+      #       ${{ env.RESULT }}
+      #       ${{ env.RESULT }}.sha256

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get the release version from the tag
         shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" | tee --append $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -49,7 +49,7 @@ jobs:
           result="$dirname.tar.gz"
           tar -czf "$result" "$dirname"
           sha256sum "$result" > "$result.sha256"
-          echo "RESULT=$result" | tee --append $GITHUB_ENV
+          echo "RESULT=$result" >> $GITHUB_ENV
       # - name: Release
       #   uses: softprops/action-gh-release@v1
       #   with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # I don't see any reason to support Window$
           - build: linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -30,17 +29,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Get the release version from the tag
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Sanity tests
+        run: cargo test --target ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Create archive
         shell: bash
         run: |
           binary_name="pandoras_pot"
-          dirname="$binary_name-${{ github.ref }}-${{ matrix.target }}"
+          dirname="$binary_name-${{ env.VERSION }}-${{ matrix.target }}"
           mkdir "$dirname"
           mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
           result="$dirname.tar.gz"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,12 @@
 name: Deploy
 
-on:
-  push
-  # push:
-  #   branches:
-  #     - "main"
-  #   tags:
-  #     - "[0-9]+.[0-9]+.[0-9]+"
-
+on: push
+#   push:
+#     branches:
+#       - "main"
+#     tags:
+#       - "[0-9]+.[0-9]+.[0-9]+"
+#
 # permissions:
 #   contents: write
 
@@ -18,6 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
+          # I don't see any reason to support Window$
           - build: linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -30,9 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get the release version from the tag
-        shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -43,16 +40,18 @@ jobs:
         shell: bash
         run: |
           binary_name="pandoras_pot"
-          dirname="$binary_name-${{ env.VERSION }}-${{ matrix.target }}"
+          dirname="$binary_name-${{ github.ref }}-${{ matrix.target }}"
           mkdir "$dirname"
           mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
           result="$dirname.tar.gz"
           tar -czf "$result" "$dirname"
-          sha256sum "$result" > "$result.sha256"
+          shasum -a 256 "$result" > "$result.sha256"
           echo "RESULT=$result" >> $GITHUB_ENV
       # - name: Release
       #   uses: softprops/action-gh-release@v1
+      #   if: startsWith(github.ref, 'refs/tags/')
       #   with:
+      #     generate_release_notes: true
       #     files: |
       #       ${{ env.RESULT }}
       #       ${{ env.RESULT }}.sha256


### PR DESCRIPTION
This will introduce automatic creation of binaries on pushing a tag with the correct format.